### PR TITLE
feat: add lock-file-name

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -14,6 +14,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { format } from './utils';
 import { info } from './debugLog';
+import { existsSync } from 'fs-extra';
 
 export class FileStructures {
   constructor(private generators: CodeGenerator[], private usingMultipleOrigins: boolean) {}
@@ -34,7 +35,7 @@ export class FileStructures {
     return {
       ...files,
       'index.ts': this.getDataSourcesTs.bind(this),
-      'api.lock': this.getLockContent.bind(this),
+      'api-lock.json': this.getLockContent.bind(this),
       'api.d.ts': this.getDataSourcesDeclarationTs.bind(this)
     };
   }
@@ -99,7 +100,7 @@ export class FileStructures {
       mods: mods,
       'index.ts': generator.getIndex.bind(generator),
       'api.d.ts': generator.getDeclaration.bind(generator),
-      'api.lock': this.getLockContent.bind(this)
+      'api-lock.json': this.getLockContent.bind(this)
     };
   }
 
@@ -434,7 +435,13 @@ export class FilesManager {
   created = false;
 
   async saveLock() {
-    const lockFile = path.join(this.baseDir, 'api.lock');
+    let lockFile = path.join(this.baseDir, 'api-lock.json');
+    const isExists = fs.existsSync(lockFile);
+
+    if (!isExists) {
+      lockFile = path.join(this.baseDir, 'api.lock');
+    }
+
     const newLockContent = this.fileStructures.getLockContent();
 
     const lockContent = await fs.readFile(lockFile, 'utf8');

--- a/src/manage.ts
+++ b/src/manage.ts
@@ -12,7 +12,7 @@ import Translate from './translate';
 import { FileStructures } from './generate';
 
 export class Manager {
-  readonly lockFilename = 'api.lock';
+  readonly lockFilename = 'api-lock.json';
 
   allLocalDataSources: StandardDataSource[] = [];
   allConfigs: DataSourceConfig[];
@@ -151,13 +151,24 @@ export class Manager {
   }
 
   existsLocal() {
-    return fs.existsSync(path.join(this.currConfig.outDir, this.lockFilename));
+    return (
+      fs.existsSync(path.join(this.currConfig.outDir, this.lockFilename)) ||
+      fs.existsSync(path.join(this.currConfig.outDir, 'api.lock'))
+    );
   }
 
   async readLocalDataSource() {
     try {
       this.report('读取本地数据中...');
-      const localDataStr = await fs.readFile(path.join(this.currConfig.outDir, this.lockFilename), {
+
+      let lockFile = path.join(this.currConfig.outDir, 'api-lock.json');
+      const isExists = fs.existsSync(lockFile);
+
+      if (!isExists) {
+        lockFile = path.join(this.currConfig.outDir, 'api.lock');
+      }
+
+      const localDataStr = await fs.readFile(lockFile, {
         encoding: 'utf8'
       });
 


### PR DESCRIPTION
把 api.lock 文件改为 api-lock.json；以防止 api.lock 在解决冲突时，不符合 JSON 格式不易被发现的问题